### PR TITLE
Dockerize, re-enable env variable api key

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.12 as statfuse
+
+COPY requirements.txt /statfuse/requirements.txt
+
+RUN pip install -r /statfuse/requirements.txt
+
+COPY . /statfuse
+
+WORKDIR /statfuse
+
+CMD ["flask", "run", "--host=0.0.0.0"]
+
+
+
+
+

--- a/README.md
+++ b/README.md
@@ -10,3 +10,9 @@
 - Activate the virtual environment with ".\venv\Scripts\activate" (depending on what terminal/OS is used this will be different, just look up activating a virtual environment with Python.
 - Install requirements with "pip install -r .\requirements.txt".
 - Use "flask run" to run the program (Changing FLASK_DEBUG in .flaskenv between 1 and 0 will toggle debug mode).
+
+
+
+# Docker
+
+A dockerfile and compose.yaml have been included to allow for easy deployment of the project.

--- a/app/api_calls.py
+++ b/app/api_calls.py
@@ -1,6 +1,6 @@
 import requests, json, os
 
-SERVICE_ID = "s:example"
+SERVICE_ID = os.environ.get('SECRET_KEY', 's:example')
 
 # returns information from census api as a json string
 def call_census(url):

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,11 @@
+
+
+
+services:
+  statfuse:
+    build: .
+    container_name: statfuse
+    ports:
+      - "5000:5000"
+    environment:
+      - SECRET_KEY=${SECRET_KEY}


### PR DESCRIPTION
Simple PR that adds a Dockerfile/compose.yaml, as well as re-enabling environment var support for the PS2 service ID ( with s:example fallback if a service ID is not found).